### PR TITLE
Scanner header file included

### DIFF
--- a/Luxury_Airlines.cpp
+++ b/Luxury_Airlines.cpp
@@ -1,4 +1,4 @@
-#include<iostream>
+#include "Scanner.h"
 int main()
 {
     return 0;


### PR DESCRIPTION
iostream not required to include as that automatically comes under the Scanner header file.